### PR TITLE
fix: bug#2

### DIFF
--- a/pt-BR/_config.json
+++ b/pt-BR/_config.json
@@ -1,6 +1,0 @@
-{
-"code": "pt-BR",
-"systemCode": "pt",
-"asianLanguage": false,
-"label": "Português Brazil"
-}


### PR DESCRIPTION
fix #2 

# Problema
- Inicialmente o repositorio do projeto foi realizado como mod para Workshop Steam, onde o tem algun nível de integração entre a plataforma Steam e o Jogo, dessa maneira os desenvolvedores do jogo fazem com que seja possivel definir uma nova informação de Linguagem no arquivo de config e o jogo "adiciona" como um novo idioma para o jogo. 
- Se realizar o processo de intralação manual da Tradução, substituindo os arquivos, o processo de "adicionar" um novo idioma não é possivel.
- O arquivo de config do Idioma está com configurações de uma nova linguagem para o jogo `pt-BR` e dessa maneira ocorre erro no jogo porque ele não encontra a referencia da configuração de Idioma.

# Solução
- Excluir o **_config.json**
- Arquivo _config.json com valores "pt-BR" só funciona instalando o mod pelo Steam Workshop

# Fix #2 
- Arquivo _config.json excluido da pasta [pt-BR](https://github.com/PoBruno/Pathway-traducao-ptbr/tree/main/pt-BR)